### PR TITLE
Bumped Varnish version from 4.1.3-r1 to 4.1.9-r0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.6
 
 RUN apk add --no-cache \
   tini \
-  varnish=4.1.3-r1
+  varnish=4.1.9-r0
 
 ENV VCL_CONFIG      /etc/varnish/default.vcl
 ENV CACHE_SIZE      64m

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Varnish on Alpine in Docker
 ===========================
 
-Varnish version: 4.1.3
+Varnish version: 4.1.9
 
 Usage
 -----


### PR DESCRIPTION
Upgrades Varnish a few patch versions ahead since the older version isn't available which breaks the image build.